### PR TITLE
fix: skip quays with blank or missing imported-id

### DIFF
--- a/src/main/java/no/rutebanken/extime/routes/stop/StopAreaRepositoryRouteBuilder.java
+++ b/src/main/java/no/rutebanken/extime/routes/stop/StopAreaRepositoryRouteBuilder.java
@@ -78,11 +78,17 @@ public class StopAreaRepositoryRouteBuilder extends BaseRouteBuilder {
 
         NetexEntitiesIndex index = exchange.getIn().getBody(NetexEntitiesIndex.class);
 
-        Function<Quay, String> findAvinorLocalReference = quay -> quay.getKeyList().getKeyValue().stream()
-                .filter(keyValueStructure -> keyValueStructure.getKey().equals("imported-id"))
-                .map(KeyValueStructure::getValue)
-                .findFirst()
-                .orElseThrow();
+        Function<Quay, String> findAvinorLocalReference = quay -> {
+            if (quay.getKeyList() == null) {
+                return null;
+            }
+            return quay.getKeyList().getKeyValue().stream()
+                    .filter(keyValueStructure -> keyValueStructure.getKey().equals("imported-id"))
+                    .map(KeyValueStructure::getValue)
+                    .filter(value -> value != null && !value.isBlank())
+                    .findFirst()
+                    .orElse(null);
+        };
 
         // Building Map like ["AVI:Quay:234" -> Quay]
         exchange.setProperty(PROPERTY_NSR_QUAY_MAP,
@@ -90,6 +96,14 @@ public class StopAreaRepositoryRouteBuilder extends BaseRouteBuilder {
                         .keySet()
                         .stream()
                         .map(quays -> index.getQuayIndex().getLatestVersion(quays))
+                        .filter(quay -> {
+                            String localReference = findAvinorLocalReference.apply(quay);
+                            if (localReference == null) {
+                                LOGGER.warn("Skipping quay {} with blank or missing imported-id", quay.getId());
+                                return false;
+                            }
+                            return true;
+                        })
                         .collect(Collectors.toMap(findAvinorLocalReference, Function.identity()))
         );
     }


### PR DESCRIPTION
## Summary
- Stop-area refresh was crashing with `IllegalStateException: Duplicate key` when building the `imported-id → Quay` map from the NeTEx stop dataset.
- Root cause: Bergen lufthavn (`NSR:StopPlace:759`) has multiple quays whose `imported-id` keyValue is an empty string (e.g. `NSR:Quay:111598` / D28 and `NSR:Quay:111599` / F25). `Collectors.toMap` doesn't permit duplicate keys, so `""` collides.
- Fix: in `StopAreaRepositoryRouteBuilder.buildAvinorLocalReferenceToQuayMap`, return `null` for quays whose `keyList` / `imported-id` value is missing or blank, filter them out before `toMap`, and log a warning so the upstream NSR data quality issue stays visible.

## Test plan
- [ ] Trigger `direct:refreshStops` against a stop dataset containing Bergen lufthavn (NSR:StopPlace:759) and verify the route completes without `IllegalStateException`.
- [ ] Verify a `WARN` log line is emitted for each skipped quay (`Skipping quay NSR:Quay:111598 with blank or missing imported-id`, etc.).
- [ ] Verify quays with valid `imported-id` values are still indexed correctly and downstream flight-to-quay resolution continues to work.